### PR TITLE
Regex Changes

### DIFF
--- a/UI/Globals.cs
+++ b/UI/Globals.cs
@@ -1,0 +1,23 @@
+﻿namespace UI
+{
+	internal static class Globals
+	{
+		private static string? CurrentWordList = null;
+		private static string? AllWords = null;
+		public async static Task<string> GetAllWords()
+		{
+			if (AllWords == null || CurrentWordList != SettingsService.WordFile)
+			{
+				CurrentWordList = SettingsService.WordFile;
+				var stream = await FileSystem.OpenAppPackageFileAsync(CurrentWordList);
+				using StreamReader reader = new(stream);
+				AllWords = (await reader.ReadToEndAsync()).ReplaceLineEndings("\n");
+				return AllWords;
+			}
+			else
+			{
+				return AllWords;
+			}
+		}
+	}
+}

--- a/UI/Pages/FinderPage.xaml
+++ b/UI/Pages/FinderPage.xaml
@@ -30,13 +30,6 @@
 					Grid.Row="0"
 					Grid.Column="0"
 					Grid.ColumnSpan="2" >
-					<Entry.Behaviors>
-						<toolkit:TextValidationBehavior
-							InvalidStyle="{StaticResource InvalidCharacters}"
-							ValidStyle="{StaticResource ValidCharacters}"
-							Flags="ValidateOnValueChanged"
-							RegexPattern="^[a-z0-9]*$" />
-					</Entry.Behaviors>
 				</Entry>
 				<Button
 					x:Name="ButtonSearch"
@@ -165,13 +158,6 @@
 			<Entry
 				x:Name="EntryExcludeCharacters"
 				Style="{StaticResource ValidCharacters}" >
-				<Entry.Behaviors>
-					<toolkit:TextValidationBehavior
-						InvalidStyle="{StaticResource InvalidCharacters}"
-						ValidStyle="{StaticResource ValidCharacters}"
-						Flags="ValidateOnValueChanged"
-						RegexPattern="^[a-z0-9]*$" />
-				</Entry.Behaviors>
 			</Entry>
 			<!--Rules-->
 			<Label

--- a/UI/Pages/FinderPage.xaml
+++ b/UI/Pages/FinderPage.xaml
@@ -107,12 +107,11 @@
 					Grid.Row="1"
 					Grid.Column="2" >
 					<Entry.Behaviors>
-						<toolkit:NumericValidationBehavior
+						<toolkit:TextValidationBehavior
 							InvalidStyle="{StaticResource InvalidNumbers}"
 							ValidStyle="{StaticResource ValidNumbers}"
 							Flags="ValidateOnValueChanged"
-							MinimumValue="1"
-							MaximumDecimalPlaces="0" />
+							RegexPattern="^[0-9]*$" />
 					</Entry.Behaviors>
 				</Entry>
 				<Entry
@@ -122,14 +121,11 @@
 					Grid.Row="2"
 					Grid.Column="2" >
 					<Entry.Behaviors>
-						<toolkit:NumericValidationBehavior
+						<toolkit:TextValidationBehavior
 							InvalidStyle="{StaticResource InvalidNumbers}"
 							ValidStyle="{StaticResource ValidNumbers}"
 							Flags="ValidateOnValueChanged"
-							MinimumValue="1"
-							MaximumDecimalPlaces="0"
-							BindingContext="{x:Reference Name=EntryMax}"
-							MaximumValue="{Binding Path=Text}"/>
+							RegexPattern="^[0-9]*$" />
 					</Entry.Behaviors>
 				</Entry>
 				<Entry
@@ -139,13 +135,11 @@
 					Grid.Row="2"
 					Grid.Column="3" >
 					<Entry.Behaviors>
-						<toolkit:NumericValidationBehavior
+						<toolkit:TextValidationBehavior
 							InvalidStyle="{StaticResource InvalidNumbers}"
 							ValidStyle="{StaticResource ValidNumbers}"
 							Flags="ValidateOnValueChanged"
-							BindingContext="{x:Reference Name=EntryMin}"
-							MinimumValue="{Binding Path=Text}"
-							MaximumDecimalPlaces="0" />
+							RegexPattern="^[0-9]*$" />
 					</Entry.Behaviors>
 				</Entry>
 			</Grid>

--- a/UI/Pages/FinderPage.xaml.cs
+++ b/UI/Pages/FinderPage.xaml.cs
@@ -33,11 +33,6 @@ public partial class FinderPage : ContentPage, IQueryAttributable
 	private async void DoSearch()
 	{
 		string characters = EntryCharacters.Text ?? "";
-		if (characters != RegexFinder.GetSafeString(characters))
-		{
-			await DisplayAlert("Invalid", "Invalid characters in characters field.", "OK");
-			return;
-		}
 		//if (!CheckBoxOnlyThese.IsChecked && !CheckBoxIncludeAll.IsChecked && PickerCount.SelectedIndex == (int)WordRegex.CountRestriction.None && characters.Length > 0)
 		//{
 		//	if (!await DisplayAlert("Warning", "'Only These' and 'Include All' are unchecked and 'Restrict Count' is set to None. This will result in the Characters field being ignored.", "Continue", "Cancel"))

--- a/UI/Pages/FinderPage.xaml.cs
+++ b/UI/Pages/FinderPage.xaml.cs
@@ -48,6 +48,7 @@ public partial class FinderPage : ContentPage, IQueryAttributable
 		Finder.IncludeAll = CheckBoxIncludeAll.IsChecked;
 		Finder.OnlyThese = CheckBoxOnlyThese.IsChecked;
 		Finder.Characters = characters;
+		Finder.ExcludeCharacters = EntryExcludeCharacters.Text ?? "";
 
 		if (RadioButtonAny.IsChecked)
 		{
@@ -96,12 +97,12 @@ public partial class FinderPage : ContentPage, IQueryAttributable
 		}
 		catch
 		{
-			await DisplayAlert("Invalid Regex", "Internal regular expression match failed.\nDouble check search criteria.", "OK");
+			await DisplayAlert("Error", $"Something went wrong. Regex: \"{regex}\"", "OK");
 			return;
 		}
 		if (foundWords.Count == 0)
 		{
-			await DisplayAlert("No Words Found", "No words found matching the criteria.", "OK");
+			await DisplayAlert("No Words Found", "No words match the criteria.", "OK");
 			return;
 		}
 		if (foundWords.Count > 10000)

--- a/UI/Pages/FinderPage.xaml.cs
+++ b/UI/Pages/FinderPage.xaml.cs
@@ -84,20 +84,15 @@ public partial class FinderPage : ContentPage, IQueryAttributable
 
 		string regex = Finder.GetRegex();
 
-		await DisplayAlert(Title, regex, "OK");
-
-		using var fileStream = await FileSystem.OpenAppPackageFileAsync("words.txt");
-		using var streamReader = new StreamReader(fileStream);
-		string content = await streamReader.ReadToEndAsync();
+		await DisplayAlert("Regex (for debugging)", regex, "OK");
 
 		List<string> foundWords = [];
 		try
 		{
-			foundWords = await Task.Run(() =>
+			foundWords = (await Task.Run(async () =>
 			{
-				string textLines = Regex.Replace(content, "(\r\n|\r|\n)", "\n");
-				return RegexFinder.FindWords(textLines, regex);
-			});
+				return RegexFinder.FindWords(await Globals.GetAllWords(), regex).AsEnumerable();
+			})).ToList();
 		}
 		catch
 		{

--- a/UI/Pages/FinderPage.xaml.cs
+++ b/UI/Pages/FinderPage.xaml.cs
@@ -62,11 +62,42 @@ public partial class FinderPage : ContentPage, IQueryAttributable
 				Finder.IsLengthRange = false;
 				Finder.WordLength = exact;
 			}
-			else if (RadioButtonRange.IsChecked && Int32.TryParse(EntryMin.Text, out int min) && Int32.TryParse(EntryMax.Text, out int max))
+			else if (RadioButtonRange.IsChecked)
 			{
 				Finder.IsLengthRange = true;
-				Finder.WordMinLength = min;
-				Finder.WordMaxLength = max;
+				var minStr = EntryMin.Text ?? "";
+				var maxStr = EntryMax.Text ?? "";
+				if (Int32.TryParse(minStr, out int min) && min > 0)
+				{
+					Finder.WordMinLength = min;
+				}
+				else if (minStr.Length == 0)
+				{
+					Finder.WordMinLength = null;
+				}
+				else
+				{
+					await DisplayAlert("Invalid Length", "Invalid length provided.", "OK");
+					return;
+				}
+				if (Int32.TryParse(maxStr, out int max) && max > 0)
+				{
+					Finder.WordMaxLength = max;
+				}
+				else if (maxStr.Length == 0)
+				{
+					Finder.WordMaxLength = null;
+				}
+				else
+				{
+					await DisplayAlert("Invalid Length", "Invalid length provided.", "OK");
+					return;
+				}
+				if (Finder.WordMinLength != null && Finder.WordMaxLength != null && Finder.WordMinLength > Finder.WordMaxLength)
+				{
+					await DisplayAlert("Invalid Length", "Minimum length is greater than maximum length.", "OK");
+					return;
+				}
 			}
 			else
 			{

--- a/UI/Pages/WordFinderResultsPage.xaml
+++ b/UI/Pages/WordFinderResultsPage.xaml
@@ -2,6 +2,7 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			 x:Class="UI.Pages.WordFinderResultsPage"
+			 x:Name="this"
 			 Title="Words Found">
 	<ScrollView>
 		<VerticalStackLayout

--- a/UI/Pages/WordFinderResultsPage.xaml.cs
+++ b/UI/Pages/WordFinderResultsPage.xaml.cs
@@ -12,8 +12,13 @@ public partial class WordFinderResultsPage : ContentPage, IQueryAttributable
 	{
 		await Task.Run(() =>
 		{
-			var temp = query["Words"] as List<string>;
-			WordsString = string.Join("\n", temp);
+			if (query.TryGetValue("Words", out var temp)) {
+				var words = temp as List<string>;
+				if (words != null)
+				{
+					WordsString = string.Join("\n", words);
+				}
+			}
 		});
 		Editor editor = new()
 		{

--- a/UI/Pages/WordFinderResultsPage.xaml.cs
+++ b/UI/Pages/WordFinderResultsPage.xaml.cs
@@ -2,7 +2,7 @@ namespace UI.Pages;
 
 public partial class WordFinderResultsPage : ContentPage, IQueryAttributable
 {
-	private string WordsString = default!;
+	private string WordsString = "";
 	public WordFinderResultsPage()
 	{
 		InitializeComponent();
@@ -13,10 +13,10 @@ public partial class WordFinderResultsPage : ContentPage, IQueryAttributable
 		await Task.Run(() =>
 		{
 			if (query.TryGetValue("Words", out var temp)) {
-				var words = temp as List<string>;
-				if (words != null)
+				if (temp is List<string> words)
 				{
 					WordsString = string.Join("\n", words);
+					this.Title = $"Words Found: {words.Count}";
 				}
 			}
 		});
@@ -33,6 +33,6 @@ public partial class WordFinderResultsPage : ContentPage, IQueryAttributable
 	}
 	private void Editor_TextChanged(object? sender, TextChangedEventArgs e)
 	{
-		((Editor)sender).Text = WordsString;
+		((Editor)sender!).Text = WordsString;
 	}
 }

--- a/UI/Popups/CharacterRulePopup.xaml
+++ b/UI/Popups/CharacterRulePopup.xaml
@@ -22,13 +22,6 @@
 			MaxLength="1"
 			BindingContext="{x:Reference this}"
 			Text="{Binding RuleCharacter}" >
-			<Entry.Behaviors>
-				<toolkit:TextValidationBehavior
-					InvalidStyle="{StaticResource InvalidCharacters}"
-					ValidStyle="{StaticResource ValidCharacters}"
-					Flags="ValidateOnValueChanged"
-					RegexPattern="^[a-z0-9]*$" />
-			</Entry.Behaviors>
 		</Entry>
 		<Label
 			Text="Rule"

--- a/UI/Popups/CharacterRulePopup.xaml
+++ b/UI/Popups/CharacterRulePopup.xaml
@@ -42,7 +42,6 @@
 				<x:Array Type="{x:Type x:String}">
 					<x:String>At Position</x:String>
 					<x:String>Not At Position</x:String>
-					<!--<x:String>Not In Word</x:String>-->
 					<x:String>Has Exact Count</x:String>
 					<x:String>Has Minimum Count</x:String>
 					<x:String>Has Maximum Count</x:String>

--- a/UI/Popups/CharacterRulePopup.xaml.cs
+++ b/UI/Popups/CharacterRulePopup.xaml.cs
@@ -42,7 +42,6 @@ public partial class CharacterRulePopup : Popup
 	[
 		RegexFinder.CharacterRule.AtPosition,
 		RegexFinder.CharacterRule.NotAtPosition,
-		//RegexFinder.CharacterRule.Exclude,
 		RegexFinder.CharacterRule.ExactCount,
 		RegexFinder.CharacterRule.MinCount,
 		RegexFinder.CharacterRule.MaxCount

--- a/UI/Popups/CharacterRulePopup.xaml.cs
+++ b/UI/Popups/CharacterRulePopup.xaml.cs
@@ -64,7 +64,7 @@ public partial class CharacterRulePopup : Popup
 	private static bool TryCreateRule(string character, int ruleIndex, string number, out RegexFinder.CharRule? rule)
 	{
 		rule = null;
-		if (character.Length != 1 || character != RegexFinder.GetSafeString(character))
+		if (character.Length != 1)
 		{
 			return false;
 		}

--- a/UI/SettingsService.cs
+++ b/UI/SettingsService.cs
@@ -1,0 +1,13 @@
+﻿namespace UI
+{
+	public sealed class SettingsService
+	{
+		const string _WordFile = "word_file";
+		const string WordFileDefault = "words.txt";
+		public static string WordFile
+		{
+			set => Preferences.Set(_WordFile, value);
+			get => Preferences.Get(_WordFile, WordFileDefault);
+		}
+	}
+}

--- a/UI/Views/FinderRuleView.xaml.cs
+++ b/UI/Views/FinderRuleView.xaml.cs
@@ -41,12 +41,11 @@ public partial class FinderRuleView : ContentView
 	{
 		{ RegexFinder.CharacterRule.AtPosition, "At Position" },
 		{ RegexFinder.CharacterRule.NotAtPosition, "Not At Position" },
-		{ RegexFinder.CharacterRule.Exclude, "Exclude Character" },
 		{ RegexFinder.CharacterRule.ExactCount, "Exact Count" },
 		{ RegexFinder.CharacterRule.MinCount, "Minimum Count" },
 		{ RegexFinder.CharacterRule.MaxCount, "Maximum Count" }
 	};
-	private RegexFinder.CharRule _rule;
+	private RegexFinder.CharRule _rule = new();
 	public RegexFinder.CharRule Rule
 	{
 		get => _rule;
@@ -70,12 +69,12 @@ public partial class FinderRuleView : ContentView
 		Rule = rule;
 	}
 
-	public event EventHandler RemoveClicked;
+	public event EventHandler? RemoveClicked;
 	protected virtual void OnRemoveClicked()
 	{
 		RemoveClicked?.Invoke(this, EventArgs.Empty);
 	}
-	public event EventHandler EditClicked;
+	public event EventHandler? EditClicked;
 	protected virtual void OnEditClicked()
 	{
 		EditClicked?.Invoke(this, EventArgs.Empty);

--- a/WordFinder/RegexFinder.cs
+++ b/WordFinder/RegexFinder.cs
@@ -42,8 +42,8 @@ namespace WordFinder
 		public List<CharRule> CharacterRules { get; set; } = [];
 		public bool RestrictWordLength { get; set; }
 		public int WordLength { get; set; }
-		public int WordMaxLength { get; set; }
-		public int WordMinLength { get; set; }
+		public int? WordMaxLength { get; set; }
+		public int? WordMinLength { get; set; }
 		public bool IsLengthRange { get; set; }
 		public CountRestriction RestrictCount { get; set; }
 		public bool IncludeAll { get; set; }
@@ -196,7 +196,19 @@ namespace WordFinder
 				if (IsLengthRange)
 				{
 					// Range length
+					if (WordMinLength != null)
+					{
 					regex += $"{{{WordMinLength},{WordMaxLength}}}";
+				}
+					else if (WordMaxLength != null)
+					{
+						regex += $"{{0,{WordMaxLength}}}";
+					}
+				else
+				{
+						// Any Length
+						regex += "+";
+					}
 				}
 				else
 				{

--- a/WordFinder/RegexFinder.cs
+++ b/WordFinder/RegexFinder.cs
@@ -38,8 +38,8 @@ namespace WordFinder
 			MaxCount =		0b100
 		}
 
-		public string Characters { get; set; } = default!;
-		public string ExcludeCharacters { get; set; } = default!;
+		public string Characters { get; set; } = "";
+		public string ExcludeCharacters { get; set; } = "";
 		public List<CharRule> CharacterRules { get; set; } = [];
 		public bool RestrictWordLength { get; set; }
 		public int WordLength { get; set; }

--- a/WordFinder/RegexFinder.cs
+++ b/WordFinder/RegexFinder.cs
@@ -348,13 +348,6 @@ namespace WordFinder
 			}
 			return list;
 		}
-		[Obsolete]
-		static public string GetSafeString(string str)
-		{
-			if (str == null) { return ""; }
-			// Replace all characters that are not alphanumeric and not empty
-			return Regex.Replace(str.ToLower(), "[^a-zA-Z0-9]", "");
-		}
 		static public string EscapeCharacters(string str)
 		{
 			string toReturn = "";


### PR DESCRIPTION
Changes to the RegexFinder class and relevant UI
- Nullable min and max for ranged length.
- Escapes dangerous characters; any character can be used now.
- Excluded characters can now be specified and are used by the finder.
- Resolve various warnings.
- Implement settings for the word file. It currently uses a default file; this will be expanded in the future.
- Changed how the word file is loaded. It will now be loaded only once (not sure if this actually improved anything).