### PR TITLE
Rule changes

### DIFF
--- a/UI/Pages/FinderPage.xaml.cs
+++ b/UI/Pages/FinderPage.xaml.cs
@@ -7,11 +7,9 @@ namespace UI.Pages;
 
 public partial class FinderPage : ContentPage, IQueryAttributable
 {
-	readonly RegexFinder Finder;
 	public FinderPage()
 	{
 		InitializeComponent();
-		Finder = new();
 	}
 	/// <summary>
 	/// Allows additional rules to be added.
@@ -45,10 +43,13 @@ public partial class FinderPage : ContentPage, IQueryAttributable
 			await DisplayAlert("No Characters", "'Only These' requires characters to be provided.", "OK");
 			return;
 		}
-		Finder.IncludeAll = CheckBoxIncludeAll.IsChecked;
-		Finder.OnlyThese = CheckBoxOnlyThese.IsChecked;
-		Finder.Characters = characters;
-		Finder.ExcludeCharacters = EntryExcludeCharacters.Text ?? "";
+		RegexFinder Finder = new()
+		{
+			IncludeAll = CheckBoxIncludeAll.IsChecked,
+			OnlyThese = CheckBoxOnlyThese.IsChecked,
+			Characters = characters,
+			ExcludeCharacters = EntryExcludeCharacters.Text ?? ""
+		};
 
 		if (RadioButtonAny.IsChecked)
 		{

--- a/UI/Pages/FinderPage.xaml.cs
+++ b/UI/Pages/FinderPage.xaml.cs
@@ -126,24 +126,24 @@ public partial class FinderPage : ContentPage, IQueryAttributable
 				return RegexFinder.FindWords(await Globals.GetAllWords(), regex).AsEnumerable();
 			})).ToList();
 		}
+		catch (FinderRuleConflictException ex)
+		{
+			await DisplayAlert("Rule Conflict", ex.Message, "OK");
+			return;
+		}
+		catch (FinderDuplicateRuleException e)
+		{
+			await DisplayAlert("Duplicate Rule", e.Message, "OK");
+			return;
+		}
 		catch
 		{
-			throw;
+			await DisplayAlert("Error", $"Something went wrong. Regex: \"{regex}\"", "OK");
+			return;
 		}
-		//catch (FinderRuleConflictException ex)
-		//{
-		//	await DisplayAlert("Rule Conflict", ex.Message, "OK");
-		//	return;
-		//}
-		//catch (FinderDuplicateRuleException e)
-		//{
-		//	await DisplayAlert("Duplicate Rule", e.Message, "OK");
-		//	return;
-		//}
 		//catch
 		//{
-		//	await DisplayAlert("Error", $"Something went wrong. Regex: \"{regex}\"", "OK");
-		//	return;
+		//	throw;
 		//}
 
 		if (foundWords.Count == 0)

--- a/UI/Pages/FinderPage.xaml.cs
+++ b/UI/Pages/FinderPage.xaml.cs
@@ -1,5 +1,4 @@
 using CommunityToolkit.Maui.Views;
-using System.Text.RegularExpressions;
 using UI.Views;
 using WordFinder;
 
@@ -17,10 +16,10 @@ public partial class FinderPage : ContentPage, IQueryAttributable
 	/// <param name="query"></param>
 	public void ApplyQueryAttributes(IDictionary<string, object> query)
 	{
-		if (query.TryGetValue("NewRule", out var rule))
+		if (query.TryGetValue("Rules", out var rules))
 		{
 			// to do
-			if (rule != null) { }
+			if (rules != null) { }
 		}
 	}
 
@@ -106,8 +105,7 @@ public partial class FinderPage : ContentPage, IQueryAttributable
 				return;
 			}
 		}
-		// Read rules
-		Finder.CharacterRules.Clear();
+		// Add rules
 		foreach (FinderRuleView rule in RuleList.Cast<FinderRuleView>())
 		{
 			Finder.AddRule(rule.Rule.Character, rule.Rule.Number, rule.Rule.RuleType);
@@ -157,7 +155,7 @@ public partial class FinderPage : ContentPage, IQueryAttributable
 	{
 		var rulePopup = new Popups.CharacterRulePopup();
 		var result = await this.ShowPopupAsync(rulePopup);
-		if (result != null && result is RegexFinder.CharRule rule)
+		if (result != null && result is FinderRuleView.RuleDefinition rule)
 		{
 			RuleList.Add(new FinderRuleView(rule, Rule_EditClicked!, Rule_RemoveClicked!));
 		}
@@ -168,7 +166,7 @@ public partial class FinderPage : ContentPage, IQueryAttributable
 		{
 			var rulePopup = new Popups.CharacterRulePopup(ruleView.Rule);
 			var result = await this.ShowPopupAsync(rulePopup);
-			if (result != null && result is RegexFinder.CharRule newRule)
+			if (result != null && result is FinderRuleView.RuleDefinition newRule)
 			{
 				ruleView.Rule = newRule;
 			}

--- a/UI/Pages/FinderPage.xaml.cs
+++ b/UI/Pages/FinderPage.xaml.cs
@@ -1,6 +1,8 @@
 using CommunityToolkit.Maui.Views;
+using System.Text.RegularExpressions;
 using UI.Views;
 using WordFinder;
+using WordFinder.Exceptions;
 
 namespace UI.Pages;
 
@@ -113,13 +115,12 @@ public partial class FinderPage : ContentPage, IQueryAttributable
 
 		// More to be added here
 
-		string regex = Finder.GetRegex();
-
-		await DisplayAlert("Regex (for debugging)", regex, "OK");
-
 		List<string> foundWords = [];
+		string regex = "";
 		try
 		{
+			regex = Finder.GetRegex();
+			await DisplayAlert("Regex (for debugging)", regex.Replace("\n", "\\n"), "OK");
 			foundWords = (await Task.Run(async () =>
 			{
 				return RegexFinder.FindWords(await Globals.GetAllWords(), regex).AsEnumerable();
@@ -127,9 +128,24 @@ public partial class FinderPage : ContentPage, IQueryAttributable
 		}
 		catch
 		{
-			await DisplayAlert("Error", $"Something went wrong. Regex: \"{regex}\"", "OK");
-			return;
+			throw;
 		}
+		//catch (FinderRuleConflictException ex)
+		//{
+		//	await DisplayAlert("Rule Conflict", ex.Message, "OK");
+		//	return;
+		//}
+		//catch (FinderDuplicateRuleException e)
+		//{
+		//	await DisplayAlert("Duplicate Rule", e.Message, "OK");
+		//	return;
+		//}
+		//catch
+		//{
+		//	await DisplayAlert("Error", $"Something went wrong. Regex: \"{regex}\"", "OK");
+		//	return;
+		//}
+
 		if (foundWords.Count == 0)
 		{
 			await DisplayAlert("No Words Found", "No words match the criteria.", "OK");

--- a/UI/Pages/WordFinderResultsPage.xaml.cs
+++ b/UI/Pages/WordFinderResultsPage.xaml.cs
@@ -16,7 +16,10 @@ public partial class WordFinderResultsPage : ContentPage, IQueryAttributable
 				if (temp is List<string> words)
 				{
 					WordsString = string.Join("\n", words);
-					this.Title = $"Words Found: {words.Count}";
+					Dispatcher.Dispatch(() =>
+					{
+						Title = $"Words Found: {words.Count}";
+					});
 				}
 			}
 		});

--- a/UI/Popups/CharacterRulePopup.xaml.cs
+++ b/UI/Popups/CharacterRulePopup.xaml.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Maui.Views;
+using UI.Views;
 using WordFinder;
 
 namespace UI.Popups;
@@ -53,14 +54,14 @@ public partial class CharacterRulePopup : Popup
 		PickerRule.SelectedIndexChanged += State_Changed!;
 		EntryNumber.TextChanged += State_Changed!;
 	}
-	public CharacterRulePopup(RegexFinder.CharRule rule) : this()
+	public CharacterRulePopup(FinderRuleView.RuleDefinition rule) : this()
 	{
 		RuleCharacter = rule.Character.ToString();
 		RuleNumber = rule.Number.ToString();
 		RuleTypeIndex = RuleList.IndexOf(rule.RuleType);
 		ButtonAddRule.Text = "Update Rule";
 	}
-	private static bool TryCreateRule(string character, int ruleIndex, string number, out RegexFinder.CharRule? rule)
+	private static bool TryCreateRule(string character, int ruleIndex, string number, out FinderRuleView.RuleDefinition? rule)
 	{
 		rule = null;
 		if (character.Length != 1)
@@ -78,8 +79,8 @@ public partial class CharacterRulePopup : Popup
 		rule = new()
 		{
 			Character = character[0],
-			Number = num,
-			RuleType = RuleList[ruleIndex]
+			RuleType = RuleList[ruleIndex],
+			Number = num
 		};
 		return true;
 	}

--- a/UI/Views/FinderRuleView.xaml.cs
+++ b/UI/Views/FinderRuleView.xaml.cs
@@ -45,8 +45,14 @@ public partial class FinderRuleView : ContentView
 		{ RegexFinder.CharacterRule.MinCount, "Minimum Count" },
 		{ RegexFinder.CharacterRule.MaxCount, "Maximum Count" }
 	};
-	private RegexFinder.CharRule _rule = new();
-	public RegexFinder.CharRule Rule
+	public class RuleDefinition
+	{
+		public char Character;
+		public RegexFinder.CharacterRule RuleType;
+		public int Number;
+	}
+	private RuleDefinition _rule = new();
+	public RuleDefinition Rule
 	{
 		get => _rule;
 		set
@@ -60,9 +66,9 @@ public partial class FinderRuleView : ContentView
 	public FinderRuleView()
 	{
 		InitializeComponent();
-		Rule = new RegexFinder.CharRule();
+		Rule = new();
 	}
-	public FinderRuleView(RegexFinder.CharRule rule, EventHandler editClicked, EventHandler removeClicked) : this()
+	public FinderRuleView(RuleDefinition rule, EventHandler editClicked, EventHandler removeClicked) : this()
 	{
 		EditClicked += editClicked;
 		RemoveClicked += removeClicked;

--- a/WordFinder/Exceptions/FinderDuplicateRuleException.cs
+++ b/WordFinder/Exceptions/FinderDuplicateRuleException.cs
@@ -1,0 +1,8 @@
+﻿namespace WordFinder.Exceptions
+{
+	public class FinderDuplicateRuleException : FinderRuleException
+	{
+		public FinderDuplicateRuleException(string message) : base(message) { }
+		public FinderDuplicateRuleException(string message, Exception innerException) : base(message, innerException) { }
+	}
+}

--- a/WordFinder/Exceptions/FinderException.cs
+++ b/WordFinder/Exceptions/FinderException.cs
@@ -1,0 +1,8 @@
+﻿namespace WordFinder.Exceptions
+{
+    public class FinderException : Exception
+    {
+        public FinderException(string message) : base(message) { }
+        public FinderException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/WordFinder/Exceptions/FinderRuleConflictException.cs
+++ b/WordFinder/Exceptions/FinderRuleConflictException.cs
@@ -1,0 +1,8 @@
+﻿namespace WordFinder.Exceptions
+{
+	public class FinderRuleConflictException : FinderRuleException
+	{
+		public FinderRuleConflictException(string message) : base(message) { }
+		public FinderRuleConflictException(string message, Exception innerException) : base(message, innerException) { }
+	}
+}

--- a/WordFinder/Exceptions/FinderRuleException.cs
+++ b/WordFinder/Exceptions/FinderRuleException.cs
@@ -1,0 +1,8 @@
+﻿namespace WordFinder.Exceptions
+{
+    public class FinderRuleException : FinderException
+    {
+        public FinderRuleException(string message) : base(message) { }
+        public FinderRuleException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/WordFinder/RegexFinder.cs
+++ b/WordFinder/RegexFinder.cs
@@ -506,20 +506,13 @@ namespace WordFinder
 		/// <returns></returns>
 		public static List<string> FindWords(string ToSearch, string regex)
 		{
-
-			MatchCollection matches = Regex.Matches(
-				ToSearch,
-				regex,
-				RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.ExplicitCapture
-			);
 			List<string> words = [];
-			foreach (Match match in matches.Cast<Match>())
+			foreach (Match match in Regex.Matches(ToSearch, regex, RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.ExplicitCapture))
 			{
-				words.Add(match.Groups[0].Value);
+				words.Add(match.Value);
 			}
 			return words;
 		}
-
 		public List<string> FindWords(string ToSearch)
 		{
 			return FindWords(ToSearch, GetRegex());


### PR DESCRIPTION
Overhauls how the regular expressions are built.
- Separates position rules and provides better checking for conflicts.
- Character positions are now part of the main capture group instead of using a lookahead.
- Overall, the regular expression should be more concise.